### PR TITLE
refactor: simplify docs to focus on steel thread ANDA

### DIFF
--- a/docs/anda/README.md
+++ b/docs/anda/README.md
@@ -1,58 +1,10 @@
-# Wrale Radiate ANDA Documentation
+# Steel Thread Documentation
 
-This documentation focuses on the core steel thread of the Wrale Radiate system.
+This documentation focuses on the core steel thread. All other documentation has been removed or simplified to maintain focus on the essential flow:
 
-## Steel Thread Definition
+1. Store an asset (MKTG → ASSET_LIB)
+2. Get it to a display (TRANSPORT)
+3. Show it correctly (BASIC_RENDER)
+4. Know if it worked (HEALTH)
 
-The steel thread represents the minimal viable path for content to flow from creation to display with confirmation:
-
-1. Store an asset
-2. Get it to a display
-3. Show it correctly
-4. Know if it worked
-
-## Core Components
-
-### Actors
-- Marketing Team (MKTG) - Creates and manages content
-- Basic Display (DISPLAY_BASIC) - Shows content
-- IT Operations (IT_OPS) - Monitors system health
-
-### Needs
-- Content Management (MKTG_CONTENT_MGMT) - Upload and organize content
-- Basic Rendering (DISP_BASIC_RENDER) - Show content on displays
-- Display Health (DISP_BASIC_HEALTH) - Report display status
-- Basic Monitoring (IT_HEALTH_BASIC) - Monitor overall system health
-
-### Capabilities
-- Asset Library (CAP_ASSET_LIB) - Store and organize content
-- Content Transport (CAP_CONTENT_TRANSPORT) - Move content to displays
-- Basic Renderer (CAP_BASIC_RENDER) - Display content
-- Health Monitor (CAP_DISPLAY_HEALTH) - Track status
-
-## Implementation Focus
-
-1. Each component should be implemented in its simplest viable form
-2. Avoid premature optimization or unnecessary complexity
-3. Focus on establishing the basic content flow before adding features
-4. Health monitoring should confirm only basic content delivery and display
-
-## Directory Structure
-
-```
-docs/anda/
-├── README.md           # This overview
-├── actors/            # Core actor documentation
-│   ├── marketing.md   # Marketing team needs
-│   ├── display.md     # Display needs
-│   └── it-ops.md     # IT operations needs
-├── capabilities/      # Core capability documentation
-│   ├── asset-lib.md   # Asset library 
-│   ├── transport.md   # Content transport
-│   ├── renderer.md    # Basic renderer
-│   └── health.md      # Health monitoring
-└── decisions/        # Key architectural decisions
-    └── steel-thread.md # Why these components
-```
-
-Each component documentation focuses only on what's needed for the steel thread functionality.
+See the actors/ and capabilities/ directories for implementation details.


### PR DESCRIPTION
This PR simplifies our ANDA documentation to focus strictly on the steel thread implementation.

## Steel Thread Focus
The core flow we're focusing on is:
1. Store an asset
2. Get it to a display
3. Show it correctly
4. Know if it worked

## Changes
### Added
- New focused actor documentation (marketing.md, display.md, it-ops.md)
- New capability documentation aligned with steel thread
- Clear steel-thread.md explaining architectural decisions

### Removed
- docs/anda/changelog/
- docs/anda/interactions/
- docs/anda/resources/
- docs/anda/states/
- Extra documentation in actors directory

### Modified
- Updated main README.md to focus on core components
- Simplified directory structure
- Removed all non-essential complexity

## Testing
- Verified all doc links are valid
- Confirmed all critical steel thread components are documented
- Ensured documentation hierarchy is clear and minimal

This change will help focus our implementation on the essential core functionality before adding complexity.